### PR TITLE
Enriching customstk with hd predicate

### DIFF
--- a/data/customstk/_over_2.ml
+++ b/data/customstk/_over_2.ml
@@ -1,0 +1,4 @@
+let concat =
+  let s1 = (v : int list) true in
+  let s2 = (v : int list) true in
+  (v : int list) (fun (u : 'fa) -> (iff (mem v u) (mem s1 u || mem s2 u)) && (implies (hd v u) (hd s1 u || hd s2 u)))

--- a/data/prim/over.ml
+++ b/data/prim/over.ml
@@ -3,9 +3,9 @@ let lt =
   let b = (v : int) true in
   (v : bool) (iff v (a < b))
 
-let intlistnil = (v : int list) (fun (u : 'fa) -> not (mem v u))
+let intlistnil = (v : int list) (fun (u : 'fa) -> (not (mem v u)) && not (hd v u))
 
 let intlistcons =
   let h = (v : int) true in
   let t = (v : int list) true in
-  (v : int list) (fun (u : 'fa) -> iff (mem v u) (mem t u || u == h))
+  (v : int list) (fun (u : 'fa) -> iff (mem v u) (mem t u || u == h) && iff (hd v u) ((u == h) && implies (hd v u) (mem v u)))


### PR DESCRIPTION
Looking at customstk with `hd`. This works with `(implies (mem v u) (mem s1 u || mem s2 u))` but not `(iff (mem v u) (mem s1 u || mem s2 u))` 