### PR TITLE
Meta

### DIFF
--- a/backend/check.ml
+++ b/backend/check.ml
@@ -75,6 +75,7 @@ let smt_neg_and_solve ctx axioms vc =
 exception SMTTIMEOUT
 
 let debug_counter = ref 0
+let smt_timeout_flag = ref false
 
 (** Unsat means true; otherwise means false *)
 let handle_check_res query_action =
@@ -87,6 +88,7 @@ let handle_check_res query_action =
   (*   if 18 == !debug_counter then failwith "end" *)
   (*   else debug_counter := !debug_counter + 1 *)
   (* in *)
+  smt_timeout_flag := false;
   match res with
   | SmtUnsat -> true
   | SmtSat model ->
@@ -96,4 +98,5 @@ let handle_check_res query_action =
       false
   | Timeout ->
       (Env.show_debug_queries @@ fun _ -> Pp.printf "@{<bold>SMTTIMEOUT@}\n");
+      smt_timeout_flag := true;
       false

--- a/data/validation/depthtree/builtin_rty.ml
+++ b/data/validation/depthtree/builtin_rty.ml
@@ -1,0 +1,80 @@
+(* let[@library] ( == ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a == b) : [%v: bool]) [@under]
+ *)
+(*
+let[@library] neq =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a != b) : [%v: bool]) [@under]
+
+let[@library] lt =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a < b) : [%v: bool]) [@under]
+
+let[@library] gt =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a > b) : [%v: bool]) [@under]
+
+let[@library] le =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a <= b) : [%v: bool]) [@under]
+
+let[@library] ge =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a >= b) : [%v: bool]) [@under]
+*)
+(* let[@library] ( + ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (v == a + b : [%v: int]) [@under]
+
+let[@library] ( - ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (v == a - b : [%v: int]) [@under]
+ *)
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+
+
+let[@library] Leaf = (leaf v : [%v: int tree]) [@under]
+
+let[@library] Node =
+  let x = (true : [%v: int]) [@over] in
+  let lt = (true : [%v: int tree]) [@over] in
+  let rt = (true : [%v: int tree]) [@over] in
+  (root v x && lch v lt && rch v rt : [%v: int tree]) [@under]
+
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_tree_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int tree]) [@under]
+
+(* let[@library] increment =
+  let n = (true : [%v: int]) [@over] in
+  (v == n + 1 : [%v: int]) [@under]
+
+let[@library] decrement =
+  let n = (true : [%v: int]) [@over] in
+  (v == n - 1 : [%v: int]) [@under]
+ *)
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/depthtree/meta-config.json
+++ b/data/validation/depthtree/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": true,
+        "show_queries": true,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "benchmark_table_file": "",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/depthtree/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/depthtree/prog.ml
+++ b/data/validation/depthtree/prog.ml
@@ -1,9 +1,10 @@
 let rec depth_tree_gen (s : int) : int tree =
-  if s == 0 then Leaf
+  if sizecheck s then Leaf
   else if bool_gen () then Leaf
   else
-    let (lt : int tree) = depth_tree_gen (s - 1) in
-    let (rt : int tree) = depth_tree_gen (s - 1) in
+    let (ss : int) = subs s in
+    let (lt : int tree) = depth_tree_gen ss in
+    let (rt : int tree) = depth_tree_gen ss in
     let (n : int) = int_gen () in
     Node (n, lt, rt)
 

--- a/data/validation/depthtree/prog1.ml
+++ b/data/validation/depthtree/prog1.ml
@@ -1,8 +1,8 @@
 let rec depth_tree_gen (s : int) : int tree =
-  if s == 0 then Leaf
+  if sizecheck s then Err
   else if bool_gen () then Leaf
   else
-    let (ss : int) = s - 1 in
+    let (ss : int) = subs s in
     let (lt : int tree) = depth_tree_gen ss in
     let (rt : int tree) = depth_tree_gen ss in
     let (n : int) = int_gen () in

--- a/data/validation/duplicatelist/builtin_rty.ml
+++ b/data/validation/duplicatelist/builtin_rty.ml
@@ -1,0 +1,28 @@
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+let[@library] Nil = (emp v : [%v: int list]) [@under]
+
+let[@library] Cons =
+  let x = (true : [%v: int]) [@over] in
+  let xs = (true : [%v: int list]) [@over] in
+  (hd v x && tl v xs : [%v: int list]) [@under]
+
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_list_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int list]) [@under]
+
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/duplicatelist/meta-config.json
+++ b/data/validation/duplicatelist/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": true,
+        "show_queries": true,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "benchmark_table_file": "",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/duplicatelist/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/duplicatelist/prog.ml
+++ b/data/validation/duplicatelist/prog.ml
@@ -1,5 +1,5 @@
 let rec duplicate_list_gen (s : int) (x : int) : int list =
-  if s == 0 then [] else x :: duplicate_list_gen (s - 1) x
+  if sizecheck s then [] else x :: duplicate_list_gen (subs s) x
 
 let[@assert] duplicate_list_gen =
   let s = (v >= 0 : [%v: int]) [@over] in

--- a/data/validation/duplicatelist/prog1.ml
+++ b/data/validation/duplicatelist/prog1.ml
@@ -1,0 +1,9 @@
+let rec duplicate_list_gen (s : int) (x : int) : int list =
+  if sizecheck s then Exn else x :: duplicate_list_gen (subs s) x
+
+let[@assert] duplicate_list_gen =
+  let s = (v >= 0 : [%v: int]) [@over] in
+  let x = (true : [%v: int]) [@over] in
+  (len v s && fun (u : int) -> (list_mem v u) #==> (u == x)
+    : [%v: int list])
+    [@under]

--- a/data/validation/rbtree/builtin_rty.ml
+++ b/data/validation/rbtree/builtin_rty.ml
@@ -1,0 +1,82 @@
+(* let[@library] ( == ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a == b) : [%v: bool]) [@under]
+ *)
+(*
+let[@library] neq =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a != b) : [%v: bool]) [@under]
+
+let[@library] lt =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a < b) : [%v: bool]) [@under]
+
+let[@library] gt =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a > b) : [%v: bool]) [@under]
+
+let[@library] le =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a <= b) : [%v: bool]) [@under]
+
+let[@library] ge =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a >= b) : [%v: bool]) [@under]
+*)
+(* let[@library] ( + ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (v == a + b : [%v: int]) [@under]
+
+let[@library] ( - ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (v == a - b : [%v: int]) [@under] *)
+
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+
+let[@library] Rbtleaf = (rb_leaf v : [%v: int rbtree]) [@under]
+
+let[@library] Rbtnode =
+  let c = (true : [%v: bool]) [@over] in
+  let x = (true : [%v: int]) [@over] in
+  let lt = (true : [%v: int rbtree]) [@over] in
+  let rt = (true : [%v: int rbtree]) [@over] in
+  (rb_root_color v c && rb_root v x && rb_lch v lt && rb_rch v rt
+    : [%v: int rbtree])
+    [@under]
+
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_rbtree_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int rbtree]) [@under]
+
+(* let[@library] increment =
+  let n = (true : [%v: int]) [@over] in
+  (v == n + 1 : [%v: int]) [@under]
+
+let[@library] decrement =
+  let n = (true : [%v: int]) [@over] in
+  (v == n - 1 : [%v: int]) [@under]
+ *)
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/rbtree/meta-config.json
+++ b/data/validation/rbtree/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": true,
+        "show_queries": true,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "benchmark_table_file": "",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/rbtree/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/rbtree/prog.ml
+++ b/data/validation/rbtree/prog.ml
@@ -1,35 +1,37 @@
 let rec rbtree_gen (inv : int) (color : bool) (h : int) : int rbtree =
-  if h == 0 then
+  if sizecheck h then
     if color then Rbtleaf
     else if bool_gen () then Rbtleaf
     else Rbtnode (true, Rbtleaf, int_gen (), Rbtleaf)
   else
-    let (hh : int) = h - 1 in
+    let (hh : int) = subs h in
     let (rt : int) = int_gen () in
     if color then
-      let (lt2 : int rbtree) = rbtree_gen (inv - 1) false hh in
-      let (rt2 : int rbtree) = rbtree_gen (inv - 1) false hh in
+      let (lt2 : int rbtree) = rbtree_gen (subs inv) false hh in
+      let (rt2 : int rbtree) = rbtree_gen (subs inv) false hh in
       Rbtnode (false, lt2, rt, rt2)
     else
       let (c : bool) = bool_gen () in
       if c then
-        let (lt3 : int rbtree) = rbtree_gen (inv - 1) true h in
-        let (rt3 : int rbtree) = rbtree_gen (inv - 1) true h in
+        let (lt3 : int rbtree) = rbtree_gen (subs inv) true h in
+        let (rt3 : int rbtree) = rbtree_gen (subs inv) true h in
         Rbtnode (true, lt3, rt, rt3)
       else
-        let (lt4 : int rbtree) = rbtree_gen (inv - 2) false hh in
-        let (rt4 : int rbtree) = rbtree_gen (inv - 2) false hh in
+        let (lt4 : int rbtree) = rbtree_gen (subs (subs inv)) false hh in
+        let (rt4 : int rbtree) = rbtree_gen (subs (subs inv)) false hh in
         Rbtnode (false, lt4, rt, rt4)
 
 let[@assert] rbtree_gen =
   let inv = (v >= 0 : [%v: int]) [@over] in
-  let c = (true : [%v: bool]) [@over] in
+  let color = (true : [%v: bool]) [@over] in
   let[@assert] h =
-    (v >= 0 && if c then v + v == inv else v + v + 1 == inv : [%v: int]) [@over]
+    (v >= 0 && if color then v + v == inv else v + v + 1 == inv
+      : [%v: int])
+      [@over]
   in
   (num_black v h && no_red_red v
    &&
-   if c then not (rb_root_color v true)
+   if color then not (rb_root_color v true)
    else (h == 0) #==> (not (rb_root_color v false))
     : [%v: int rbtree])
     [@under]

--- a/data/validation/sizedlist/builtin_rty.ml
+++ b/data/validation/sizedlist/builtin_rty.ml
@@ -1,0 +1,28 @@
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+let[@library] Nil = (emp v : [%v: int list]) [@under]
+
+let[@library] Cons =
+  let x = (true : [%v: int]) [@over] in
+  let xs = (true : [%v: int list]) [@over] in
+  (hd v x && tl v xs : [%v: int list]) [@under]
+
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_list_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int list]) [@under]
+
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/sizedlist/meta-config.json
+++ b/data/validation/sizedlist/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": false,
+        "show_queries": false,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "benchmark_table_file": "",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/sizedlist/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/sizedlist/prog.ml
+++ b/data/validation/sizedlist/prog.ml
@@ -1,7 +1,7 @@
 let rec sized_list_gen (s : int) : int list =
-  if s == 0 then []
+  if sizecheck s then []
   else if bool_gen () then []
-  else int_gen () :: sized_list_gen (s - 1)
+  else int_gen () :: sized_list_gen (subs s)
 
 let[@assert] sized_list_gen =
   let s = (0 <= v : [%v: int]) [@over] in

--- a/data/validation/sizedlist/prog1.ml
+++ b/data/validation/sizedlist/prog1.ml
@@ -1,0 +1,8 @@
+let rec sized_list_gen (s : int) : int list =
+  if sizecheck s then Err
+  else if bool_gen () then []
+  else int_gen () :: sized_list_gen (subs s)
+
+let[@assert] sized_list_gen =
+  let s = (0 <= v : [%v: int]) [@over] in
+  (fun ((n [@exists]) : int) -> len v n && n <= s : [%v: int list]) [@under]

--- a/data/validation/sizedlist/prog2.ml
+++ b/data/validation/sizedlist/prog2.ml
@@ -1,0 +1,8 @@
+let rec sized_list_gen (s : int) : int list =
+  if sizecheck s then []
+  else if bool_gen () then Err
+  else int_gen () :: sized_list_gen (subs s)
+
+let[@assert] sized_list_gen =
+  let s = (0 <= v : [%v: int]) [@over] in
+  (fun ((n [@exists]) : int) -> len v n && n <= s : [%v: int list]) [@under]

--- a/data/validation/sizedlist/prog3.ml
+++ b/data/validation/sizedlist/prog3.ml
@@ -1,0 +1,6 @@
+let rec sized_list_gen (s : int) : int list =
+  if sizecheck s then [] else if bool_gen () then [] else Err
+
+let[@assert] sized_list_gen =
+  let s = (0 <= v : [%v: int]) [@over] in
+  (fun ((n [@exists]) : int) -> len v n && n <= s : [%v: int list]) [@under]

--- a/data/validation/sortedlist/builtin_rty.ml
+++ b/data/validation/sortedlist/builtin_rty.ml
@@ -1,0 +1,33 @@
+let[@library] ( <= ) =
+  let a = (true : [%v: int]) [@over] in
+  let b = (true : [%v: int]) [@over] in
+  (iff v (a <= b) : [%v: bool]) [@under]
+
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+let[@library] Nil = (emp v : [%v: int list]) [@under]
+
+let[@library] Cons =
+  let x = (true : [%v: int]) [@over] in
+  let xs = (true : [%v: int list]) [@over] in
+  (hd v x && tl v xs : [%v: int list]) [@under]
+
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_list_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int list]) [@under]
+
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/sortedlist/meta-config.json
+++ b/data/validation/sortedlist/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": true,
+        "show_queries": true,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "benchmark_table_file": "",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/sortedlist/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/sortedlist/prog.ml
+++ b/data/validation/sortedlist/prog.ml
@@ -1,0 +1,17 @@
+let rec sorted_list_gen (s : int) (x : int) : int list =
+  if sizecheck s then []
+  else
+    let (y : int) = int_gen () in
+    if x <= y then
+      let (size2 : int) = subs s in
+      let (l : int list) = sorted_list_gen size2 y in
+      let (l2 : int list) = y :: l in
+      l2
+    else Exn
+
+let[@assert] sorted_list_gen =
+  let s = (0 <= v : [%v: int]) [@over] in
+  let x = (true : [%v: int]) [@over] in
+  (len v s && sorted v && fun (u : int) -> (hd v u) #==> (x <= u)
+    : [%v: int list])
+    [@under]

--- a/data/validation/sortedlist/prog1.ml
+++ b/data/validation/sortedlist/prog1.ml
@@ -1,19 +1,13 @@
-let rec sorted_list_gen (size : int) (x : int) : int list =
-  let (b : bool) = size == 0 in
-  if b then []
+let rec sorted_list_gen (s : int) (x : int) : int list =
+  if sizecheck s then Exn
   else
     let (y : int) = int_gen () in
     if x <= y then
-      let (size2 : int) = size - 1 in
+      let (size2 : int) = subs s in
       let (l : int list) = sorted_list_gen size2 y in
       let (l2 : int list) = y :: l in
       l2
     else Exn
-
-(* let[@assert] sorted_list_gen = *)
-(*   let s = (0 <= v : [%v: int]) [@over] in *)
-(*   let x = (true : [%v: int]) [@over] in *)
-(*   (lenF v == s : [%v: int list]) [@under] *)
 
 let[@assert] sorted_list_gen =
   let s = (0 <= v : [%v: int]) [@over] in

--- a/data/validation/uniquelist/builtin_rty.ml
+++ b/data/validation/uniquelist/builtin_rty.ml
@@ -11,6 +11,7 @@ let[@library] list_mem =
   let xs = (true : [%v: int list]) [@over] in
   let x = (true : [%v: int]) [@over] in
   (v == list_mem xs x : [%v: bool]) [@under]
+
 let[@library] bool_gen =
   let _ = (true : [%v: unit]) [@over] in
   (true : [%v: bool]) [@under]

--- a/data/validation/uniquelist/builtin_rty.ml
+++ b/data/validation/uniquelist/builtin_rty.ml
@@ -1,0 +1,32 @@
+let[@library] True = (v : [%v: bool]) [@under]
+let[@library] False = (not v : [%v: bool]) [@under]
+let[@library] Nil = (emp v : [%v: int list]) [@under]
+
+let[@library] Cons =
+  let x = (true : [%v: int]) [@over] in
+  let xs = (true : [%v: int list]) [@over] in
+  (hd v x && tl v xs : [%v: int list]) [@under]
+
+let[@library] list_mem =
+  let xs = (true : [%v: int list]) [@over] in
+  let x = (true : [%v: int]) [@over] in
+  (v == list_mem xs x : [%v: bool]) [@under]
+let[@library] bool_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: bool]) [@under]
+
+let[@library] int_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int]) [@under]
+
+let[@library] hidden_list_gen =
+  let _ = (true : [%v: unit]) [@over] in
+  (true : [%v: int list]) [@under]
+
+let[@library] sizecheck =
+  let x = (true : [%v: int]) [@over] in
+  (iff v (x == 0) && iff (not v) (x > 0) : [%v: bool]) [@under]
+
+let[@library] subs =
+  let s = (true : [%v: int]) [@over] in
+  (v == s - 1 : [%v: int]) [@under]

--- a/data/validation/uniquelist/meta-config.json
+++ b/data/validation/uniquelist/meta-config.json
@@ -1,0 +1,27 @@
+{
+    "mode": "debug",
+    "max_printing_size": 300,
+    "debug_info": {
+        "show_preprocess": false,
+        "show_typing": true,
+        "show_queries": true,
+        "show_stat": false,
+        "show_others": false
+    },
+    "logfile": ".log",
+    "resfile": ".result",
+    "synth_bound": 3,
+    "synth_timeout": "999",
+    "benchmark_table_file": "",
+    "prim_path": {
+        "data_type_decls": "underapproximation_type/data/predefined/data_type_decls.ml",
+        "templates": "underapproximation_type/data/predefined/templates.ml",
+        "normal_typing": "underapproximation_type/data/predefined/normal_typing.ml",
+        "axioms_of_predicates": "underapproximation_type/data/predefined/axioms.ml",
+        "axioms_of_query_encoding": "underapproximation_type/data/predefined/axioms_of_query_encoding.ml",
+        "builtin_coverage_typing": "underapproximation_type/data/validation/uniquelist/builtin_rty.ml",
+        "builtin_randomness_coverage_typing": "underapproximation_type/data/predefined/builtin_randomness_coverage_typing.ml",
+        "builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/builtin_datatype_coverage_typing",
+        "rev_builtin_datatype_coverage_typing": "underapproximation_type/data/predefined/rev_builtin_datatype_coverage_typing"
+    }
+}

--- a/data/validation/uniquelist/prog.ml
+++ b/data/validation/uniquelist/prog.ml
@@ -1,7 +1,7 @@
 let rec unique_list_gen (s : int) : int list =
-  if s == 0 then []
+  if sizecheck s then []
   else
-    let (l : int list) = unique_list_gen (s - 1) in
+    let (l : int list) = unique_list_gen (subs s) in
     let (x : int) = int_gen () in
     if list_mem l x then Err else x :: l
 

--- a/data/validation/uniquelist/prog1.ml
+++ b/data/validation/uniquelist/prog1.ml
@@ -1,0 +1,10 @@
+let rec unique_list_gen (s : int) : int list =
+  if sizecheck s then Err
+  else
+    let (l : int list) = unique_list_gen (subs s) in
+    let (x : int) = int_gen () in
+    if list_mem l x then Err else x :: l
+
+let[@assert] unique_list_gen =
+  let s = (v >= 0 : [%v: int]) [@over] in
+  (len v s && uniq v : [%v: int list]) [@under]

--- a/frontend_opt/to_prop.ml
+++ b/frontend_opt/to_prop.ml
@@ -94,7 +94,7 @@ let coqsetting =
   {
     sym_true = "True";
     sym_false = "False";
-    sym_and = "/\\ ";
+    sym_and = " /\\ ";
     sym_or = " \\/ ";
     sym_not = "~";
     sym_implies = "->";

--- a/syntax/constant.ml
+++ b/syntax/constant.ml
@@ -9,6 +9,15 @@ type constant =
   | Dt of string * constant list
 [@@deriving sexp]
 
+let rec constant_to_nt c =
+  let open Nt in
+  match c with
+  | U -> unit_ty
+  | B _ -> bool_ty
+  | I _ -> int_ty
+  | Tu l -> Nt.Ty_tuple (List.map constant_to_nt l)
+  | Dt _ -> failwith "Not implemented"
+
 let compare_constant e1 e2 =
   Sexplib.Sexp.compare (sexp_of_constant e1) (sexp_of_constant e2)
 

--- a/syntax/term.ml
+++ b/syntax/term.ml
@@ -259,6 +259,7 @@ let typed_subst_match_case_instance x instance e =
 (* Generated from _term.ml *)
 open Sugar
 
+let constant_to_value c = (VConst c) #: (constant_to_nt c)
 let value_to_term v = (CVal v) #: v.ty
 
 let term_to_value e =

--- a/syntax/typectx.ml
+++ b/syntax/typectx.ml
@@ -3,6 +3,12 @@ open Mtyped
 
 type 't ctx = Typectx of ('t, string) typed list [@@deriving sexp]
 
+let map_ctx_typed (f : ('t, string) typed -> ('t, string) typed)
+    (ctx_e : 't ctx) =
+  match ctx_e with
+  | Typectx _t_stringtypedlist0 ->
+      Typectx (List.map (fun x -> f x) _t_stringtypedlist0)
+
 let rec map_ctx (f : 't -> 's) (ctx_e : 't ctx) =
   match ctx_e with
   | Typectx _t_stringtypedlist0 ->
@@ -29,3 +35,4 @@ let add_to_right : 'a. 'a ctx -> ('a, string) typed -> 'a ctx =
   | None -> ( match ctx with Typectx l -> Typectx (l @ [ { x; ty } ]))
 
 let add_to_rights ctx l = List.fold_left add_to_right ctx l
+let to_list ctx = match ctx with Typectx l -> l


### PR DESCRIPTION
This is the current diff

The timeout flag might still be useful and is minimally invasive that I will leave it in for now.

I have gone and set up a minimal benchmark directory in validation. The structure is similar to as mentioned before.

- a `builtin_rty.ml` file that contains the minimal set of language constructs to typecheck/synthesize the program
- a `meta-config.json` file that is modified to contain 2 synthesis specific parameters (bounds and timeout) and the location of the `builtin_rty.ml` file. It should otherwise pull in all of the same axiom and typing files that you use. The paths might be slightly off if you are using them from within which we can adjust. If you want to use benchmark specific template files those should be specified here.
- `prog.ml` which is the safe and complete generator for sanity purposes
- `prog<N>.ml` which is the Nth incomplete generator that we would like to repair. I've tried to include atleast a `prog1.ml` with the simplest possible repair to start

I am flexible on this setup, just let me know what you want to change